### PR TITLE
Add insurance verification module

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -27,7 +27,8 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "nodemailer": "^7.0.3",
-    "twilio": "^5.5.2"
+    "twilio": "^5.5.2",
+    "axios": "^1.9.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -401,5 +401,29 @@ model EmailLog {
   
   @@index([to])
   @@index([sentAt])
+
   @@index([status])
+
+}
+model InsuranceVerification {
+  id                 String    @id @default(uuid())
+  clientId           String
+  client             ClientProfile @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  verifiedBy         String
+  user               User      @relation(fields: [verifiedBy], references: [id])
+  status             String
+  deductibleRemaining Int?
+  copay              Int?
+  coinsurance        Int?
+  allowedVisits      Int?
+  telehealthCovered  Boolean?
+  preAuthRequired    Boolean?
+  rawResponse        Json?
+  changes            Json?
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+
+  @@index([clientId])
+  @@index([verifiedBy])
+  @@index([createdAt])
 }

--- a/packages/backend/src/controllers/insuranceController.ts
+++ b/packages/backend/src/controllers/insuranceController.ts
@@ -1,0 +1,18 @@
+import { Request, Response, NextFunction } from 'express';
+import { insuranceVerificationService } from '../services/insuranceVerificationService';
+
+export const insuranceController = {
+  async verify(req: Request, res: Response, next: NextFunction) {
+    try {
+      const clientId = req.params.clientId || req.body.clientId;
+      if (!clientId) {
+        return res.status(400).json({ message: 'clientId is required' });
+      }
+      const info = req.body;
+      const result = await insuranceVerificationService.verify(clientId, req.user!.userId, info);
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+};

--- a/packages/backend/src/routes/insuranceRoutes.ts
+++ b/packages/backend/src/routes/insuranceRoutes.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import { authenticate, requireRole } from '../middlewares/authMiddleware';
+import { insuranceController } from '../controllers/insuranceController';
+
+const router = express.Router();
+
+router.post('/verify/:clientId?', authenticate, requireRole(['THERAPIST', 'ADMIN']), insuranceController.verify);
+
+export default router;

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -12,6 +12,7 @@ import clientRoutes from './routes/clientRoutes';
 import therapistRoutes from './routes/therapistRoutes';
 import appointmentRoutes from './routes/appointmentRoutes';
 import phiRoutes from './routes/phiRoutes';
+import insuranceRoutes from './routes/insuranceRoutes';
 
 // Security middleware
 import { securityHeadersMiddleware } from './middlewares/security/securityHeadersMiddleware';
@@ -72,6 +73,7 @@ app.use('/api/clients', clientRoutes);
 app.use('/api/therapists', therapistRoutes);
 app.use('/api/appointments', appointmentRoutes);
 app.use('/api/phi', phiRoutes);
+app.use('/api/insurance', insuranceRoutes);
 
 // Health check endpoint
 app.get('/health', (req, res) => {

--- a/packages/backend/src/services/insuranceVerificationService.ts
+++ b/packages/backend/src/services/insuranceVerificationService.ts
@@ -1,0 +1,190 @@
+import axios from 'axios';
+import { prisma } from '../lib/prisma';
+import { phiVaultService } from './encryption/phiVaultService';
+import { createAuditLog } from '../utils/auditLog';
+
+export interface InsuranceInfo {
+  fullName: string;
+  dateOfBirth: string;
+  insuranceProvider: string;
+  memberId: string;
+  groupNumber?: string;
+  cardFrontImage?: string;
+  cardBackImage?: string;
+}
+
+export interface VerificationResult {
+  active: boolean;
+  deductibleRemaining?: number | null;
+  copay?: number | null;
+  coinsurance?: number | null;
+  allowedVisits?: number | null;
+  telehealthCovered?: boolean | null;
+  preAuthRequired?: boolean | null;
+  summary: string;
+  raw: any;
+  changes?: Record<string, any> | null;
+}
+
+const CLEARINGHOUSE_URL = process.env.CLEARINGHOUSE_URL || '';
+const CLEARINGHOUSE_API_KEY = process.env.CLEARINGHOUSE_API_KEY || '';
+
+async function callClearinghouse(info: InsuranceInfo): Promise<any> {
+  // In a real implementation, this would send a 270 request and parse the 271 response.
+  // Here we mock the response for offline development.
+  try {
+    if (!CLEARINGHOUSE_URL) {
+      // Mocked sample response
+      return {
+        active: true,
+        deductibleRemaining: 300,
+        copay: 20,
+        coinsurance: 0.2,
+        allowedVisits: 20,
+        preAuthRequired: false,
+        telehealthCovered: true
+      };
+    }
+    const response = await axios.post(
+      `${CLEARINGHOUSE_URL}/eligibility`,
+      info,
+      {
+        headers: {
+          'x-api-key': CLEARINGHOUSE_API_KEY
+        }
+      }
+    );
+    return response.data;
+  } catch (error) {
+    throw new Error('Clearinghouse request failed');
+  }
+}
+
+function buildSummary(result: VerificationResult): string {
+  const parts: string[] = [];
+  if (result.active) {
+    parts.push('Client is covered');
+  } else {
+    parts.push('Client is not currently covered');
+  }
+
+  if (result.telehealthCovered) {
+    parts.push('for telehealth psychotherapy');
+  } else {
+    parts.push('for psychotherapy (telehealth uncertain)');
+  }
+
+  if (result.copay != null) {
+    parts.push(`$${result.copay} copay`);
+  }
+  if (result.deductibleRemaining != null) {
+    parts.push(`${result.deductibleRemaining} deductible remaining`);
+  }
+  if (result.allowedVisits != null) {
+    parts.push(`${result.allowedVisits} visits/year`);
+  }
+  if (result.preAuthRequired) {
+    parts.push('pre-auth required');
+  } else {
+    parts.push('no pre-auth required');
+  }
+  return parts.join('. ') + '.';
+}
+
+export const insuranceVerificationService = {
+  async verify(clientId: string, userId: string, info: InsuranceInfo): Promise<VerificationResult> {
+    // Limit checks to once every 30 days unless overridden
+    const last = await prisma.insuranceVerification.findFirst({
+      where: { clientId },
+      orderBy: { createdAt: 'desc' }
+    });
+    const now = new Date();
+    if (last && now.getTime() - last.createdAt.getTime() < 1000 * 60 * 60 * 24 * 30) {
+      return {
+        active: last.status === 'ACTIVE',
+        deductibleRemaining: last.deductibleRemaining,
+        copay: last.copay,
+        coinsurance: last.coinsurance,
+        allowedVisits: last.allowedVisits,
+        telehealthCovered: last.telehealthCovered,
+        preAuthRequired: last.preAuthRequired,
+        summary: buildSummary({
+          active: last.status === 'ACTIVE',
+          deductibleRemaining: last.deductibleRemaining,
+          copay: last.copay,
+          coinsurance: last.coinsurance,
+          allowedVisits: last.allowedVisits,
+          telehealthCovered: last.telehealthCovered,
+          preAuthRequired: last.preAuthRequired,
+          raw: last.rawResponse,
+          summary: ''
+        }),
+        raw: last.rawResponse,
+        changes: null
+      };
+    }
+
+    const response = await callClearinghouse(info);
+
+    const result: VerificationResult = {
+      active: !!response.active,
+      deductibleRemaining: response.deductibleRemaining ?? null,
+      copay: response.copay ?? null,
+      coinsurance: response.coinsurance ?? null,
+      allowedVisits: response.allowedVisits ?? null,
+      telehealthCovered: response.telehealthCovered ?? null,
+      preAuthRequired: response.preAuthRequired ?? null,
+      summary: '',
+      raw: response,
+      changes: null
+    };
+
+    const changes: Record<string, any> = {};
+    if (last) {
+      for (const key of ['status','deductibleRemaining','copay','coinsurance','allowedVisits','telehealthCovered','preAuthRequired']) {
+        const newVal = (result as any)[key] ?? null;
+        const oldVal = (last as any)[key] ?? null;
+        if (newVal !== oldVal) {
+          changes[key] = { old: oldVal, new: newVal };
+        }
+      }
+    }
+    result.changes = Object.keys(changes).length > 0 ? changes : null;
+    result.summary = buildSummary(result);
+
+    await prisma.insuranceVerification.create({
+      data: {
+        clientId,
+        verifiedBy: userId,
+        status: result.active ? 'ACTIVE' : 'INACTIVE',
+        deductibleRemaining: result.deductibleRemaining ?? null,
+        copay: result.copay ?? null,
+        coinsurance: result.coinsurance ?? null,
+        allowedVisits: result.allowedVisits ?? null,
+        telehealthCovered: result.telehealthCovered ?? null,
+        preAuthRequired: result.preAuthRequired ?? null,
+        rawResponse: result.raw,
+        changes: result.changes
+      }
+    });
+
+    await createAuditLog(userId, 'VERIFY_INSURANCE', 'ClientProfile', clientId, result);
+
+    return result;
+  },
+
+  async storeInsurancePHI(clientId: string, userId: string, info: InsuranceInfo) {
+    // Store sensitive fields in PHI vault
+    await phiVaultService.storePHI(userId, info.fullName, 'NAME', userId);
+    await phiVaultService.storePHI(userId, info.memberId, 'INSURANCE_ID', userId);
+    if (info.groupNumber) {
+      await phiVaultService.storePHI(userId, info.groupNumber, 'GROUP_ID', userId);
+    }
+    if (info.cardFrontImage) {
+      await phiVaultService.storePHI(userId, info.cardFrontImage, 'INSURANCE_CARD_FRONT', userId);
+    }
+    if (info.cardBackImage) {
+      await phiVaultService.storePHI(userId, info.cardBackImage, 'INSURANCE_CARD_BACK', userId);
+    }
+  }
+};

--- a/packages/backend/src/tests/insurance.service.test.ts
+++ b/packages/backend/src/tests/insurance.service.test.ts
@@ -1,0 +1,26 @@
+import { insuranceVerificationService } from '../services/insuranceVerificationService';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+beforeAll(async () => {
+  await prisma.insuranceVerification.deleteMany({});
+});
+
+afterAll(async () => {
+  await prisma.insuranceVerification.deleteMany({});
+  await prisma.$disconnect();
+});
+
+describe('Insurance Verification Service', () => {
+  test('should verify insurance with mocked response', async () => {
+    const result = await insuranceVerificationService.verify('test-client', 'tester', {
+      fullName: 'John Doe',
+      dateOfBirth: '1990-01-01',
+      insuranceProvider: 'Mock',
+      memberId: '12345'
+    });
+    expect(result).toBeDefined();
+    expect(result.summary).toContain('Client is covered');
+  });
+});


### PR DESCRIPTION
## Summary
- add an `InsuranceVerification` Prisma model
- implement `insuranceVerificationService` with mocked clearinghouse call
- create controller and routes for verifying insurance
- mount insurance routes in the server
- add axios dependency for backend
- provide Jest test for the new service

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855945942488327a168ae3dcc67b5de